### PR TITLE
Added Match convenience method to prevent errors when coding $(match)

### DIFF
--- a/jOOX/src/main/java/org/joox/JOOX.java
+++ b/jOOX/src/main/java/org/joox/JOOX.java
@@ -217,6 +217,18 @@ public final class JOOX {
             return $(context.match());
         }
     }
+    
+    /**
+     * Convenience method for calling <code>$(match)</code>
+     */
+    public static Match $(Match match) {
+        if (match == null) {
+            return $();
+        }
+        else {
+            return match;
+        }
+    }
 
     /**
      * Convenience method for calling <code>$(url.openStream())</code>


### PR DESCRIPTION
A simple little convenience method that returns the supplied match so that coding $(match) doesn't throw an error.
