### PR TITLE
Simplifying generated XPath when there is only a single sibiling

### DIFF
--- a/jOOX/src/main/java/org/joox/Util.java
+++ b/jOOX/src/main/java/org/joox/Util.java
@@ -275,9 +275,10 @@ class Util {
 
         Node iterator = element;
         while (iterator.getNodeType() == Node.ELEMENT_NODE) {
-            sb.insert(0, "]");
-            sb.insert(0, siblingIndex((Element) iterator) + 1);
-            sb.insert(0, "[");
+            Integer siblingIndex = siblingIndex((Element) iterator);
+            if (siblingIndex != null) {
+                sb.insert(0, "[" + (siblingIndex + 1) + "]");
+            }
             sb.insert(0, ((Element) iterator).getTagName());
             sb.insert(0, "/");
 
@@ -307,18 +308,18 @@ class Util {
     /**
      * Find the index among siblings of the same tag name
      */
-    private static final int siblingIndex(Element element) {
-
-        // The document element has index 0
+    private static final Integer siblingIndex(Element element) {
         if (element.getParentNode() == element.getOwnerDocument()) {
-            return 0;
+            return null;
+        } else if ($(element).parent().children(element.getTagName()).get()
+                .size() == 1) {
+            // if there is only one child, omit the specifier
+            return null;
         }
-
         // All other elements are compared with siblings with the same name
         // TODO: How to deal with namespaces here? Omit or keep?
-        else {
-            return $(element).parent().children(element.getTagName()).get().indexOf(element);
-        }
+        return $(element).parent().children(element.getTagName()).get()
+                .indexOf(element);
     }
 
     /**

--- a/jOOX/src/test/java/org/joox/test/JOOXTest.java
+++ b/jOOX/src/test/java/org/joox/test/JOOXTest.java
@@ -1569,37 +1569,37 @@ public class JOOXTest {
 
     @Test
     public void testXPath() throws Exception {
-        assertEquals("/document[1]", $.xpath());
-        assertEquals("/document[1]", $.xpath(0));
+        assertEquals("/document", $.xpath());
+        assertEquals("/document", $.xpath(0));
         assertEquals(null, $.xpath(1));
-        assertEquals(Arrays.asList("/document[1]"), $.xpaths());
-        assertEquals(Arrays.asList("/document[1]", null), $.xpaths(0, 1));
+        assertEquals(Arrays.asList("/document"), $.xpaths());
+        assertEquals(Arrays.asList("/document", null), $.xpaths(0, 1));
 
-        assertEquals("/document[1]/library[1]/books[1]/book[1]", $.find("book").xpath());
-        assertEquals("/document[1]/library[1]/books[1]/book[1]", $.find("book").xpath(0));
-        assertEquals("/document[1]/library[1]/books[1]/book[2]", $.find("book").xpath(1));
-        assertEquals("/document[1]/library[1]/books[1]/book[3]", $.find("book").xpath(2));
-        assertEquals("/document[1]/library[1]/books[1]/book[4]", $.find("book").xpath(3));
-        assertEquals("/document[1]/library[2]/books[1]/book[1]", $.find("book").xpath(4));
-        assertEquals("/document[1]/library[2]/books[1]/book[2]", $.find("book").xpath(5));
-        assertEquals("/document[1]/library[3]/books[1]/book[1]", $.find("book").xpath(6));
-        assertEquals("/document[1]/library[3]/books[1]/book[2]", $.find("book").xpath(7));
+        assertEquals("/document/library[1]/books/book[1]", $.find("book").xpath());
+        assertEquals("/document/library[1]/books/book[1]", $.find("book").xpath(0));
+        assertEquals("/document/library[1]/books/book[2]", $.find("book").xpath(1));
+        assertEquals("/document/library[1]/books/book[3]", $.find("book").xpath(2));
+        assertEquals("/document/library[1]/books/book[4]", $.find("book").xpath(3));
+        assertEquals("/document/library[2]/books/book[1]", $.find("book").xpath(4));
+        assertEquals("/document/library[2]/books/book[2]", $.find("book").xpath(5));
+        assertEquals("/document/library[3]/books/book[1]", $.find("book").xpath(6));
+        assertEquals("/document/library[3]/books/book[2]", $.find("book").xpath(7));
         assertEquals(null, $.find("book").xpath(8));
         assertEquals(Arrays.asList(
-            "/document[1]/library[1]/books[1]/book[1]",
-            "/document[1]/library[1]/books[1]/book[2]",
-            "/document[1]/library[1]/books[1]/book[3]",
-            "/document[1]/library[1]/books[1]/book[4]",
-            "/document[1]/library[2]/books[1]/book[1]",
-            "/document[1]/library[2]/books[1]/book[2]",
-            "/document[1]/library[3]/books[1]/book[1]",
-            "/document[1]/library[3]/books[1]/book[2]"),
+            "/document/library[1]/books/book[1]",
+            "/document/library[1]/books/book[2]",
+            "/document/library[1]/books/book[3]",
+            "/document/library[1]/books/book[4]",
+            "/document/library[2]/books/book[1]",
+            "/document/library[2]/books/book[2]",
+            "/document/library[3]/books/book[1]",
+            "/document/library[3]/books/book[2]"),
             $.find("book").xpaths());
 
         assertEquals(asList(
-            "/document[1]/library[1]/dvds[1]/dvd[1]/actors[1]/actor[1]",
-            "/document[1]/library[1]/dvds[1]/dvd[1]/actors[1]/actor[2]",
-            "/document[1]/library[1]/dvds[1]/dvd[1]/actors[1]/actor[3]"),
+            "/document/library[1]/dvds/dvd/actors/actor[1]",
+            "/document/library[1]/dvds/dvd/actors/actor[2]",
+            "/document/library[1]/dvds/dvd/actors/actor[3]"),
             $.find("actor").xpaths());
     }
 


### PR DESCRIPTION
Hi Lukas,

Thanks for this great library. 

I am using jOOX with HTML having heard about it here
http://stackoverflow.com/questions/4746299/generate-get-xpath-from-xml-node-java

When jOOX generates an XPath, it will add [1] even if there is only a single element. For example for a HTML document the generated XPath will start /html[1]/body[1] even though we only expect one html and one body element. This is mainly a problem for human readability. 

I have modified the code to add a check to omit the sibling specifier if there is only a single sibling, and I have updated the unit tests accordingly.

What do you think?
