### PR TITLE
content() should give xml content with escaped characters instead of plain text

### DIFF
--- a/jOOX/pom.xml
+++ b/jOOX/pom.xml
@@ -252,7 +252,11 @@
             <type>jar</type>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.1</version>
+        </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>

--- a/jOOX/src/main/java/org/joox/Impl.java
+++ b/jOOX/src/main/java/org/joox/Impl.java
@@ -67,6 +67,7 @@ import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 import javax.xml.xpath.XPathVariableResolver;
 
+import org.apache.commons.text.StringEscapeUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.DocumentFragment;
 import org.w3c.dom.Element;
@@ -1422,7 +1423,8 @@ class Impl implements Match {
 
         // The element contains only text
         else if (Util.textNodesOnly(children)) {
-            return element.getTextContent();
+            String textContent = element.getTextContent();
+            return StringEscapeUtils.escapeXml10(textContent);
         }
 
         // The element contains content

--- a/jOOX/src/test/java/org/joox/test/JOOXTest.java
+++ b/jOOX/src/test/java/org/joox/test/JOOXTest.java
@@ -1291,9 +1291,9 @@ public class JOOXTest {
         assertEquals("Claudia Cardinale", $.find("actor").content(2));
 
         assertEquals("<><aa>", $.find("actors").content("<><aa>").text());
-        assertEquals("<><aa>", $.find("actors").content());
+        assertEquals("&lt;&gt;&lt;aa&gt;", $.find("actors").content());
         assertEquals("<abc><x></abc>", $.find("actors").content("<abc><x></abc>").text());
-        assertEquals("<abc><x></abc>", $.find("actors").content());
+        assertEquals("&lt;abc&gt;&lt;x&gt;&lt;/abc&gt;", $.find("actors").content());
         assertEquals("", $.find("actors").content("<abc><x/></abc>").text());
         assertEquals("<abc><x/></abc>", $.find("actors").content());
         assertEquals(1, $.find("abc").size());
@@ -1459,7 +1459,7 @@ public class JOOXTest {
         assertEquals(1, $.find("director").append("<><aa>").size());
         assertEquals(0, $.find("director").children().size());
         assertEquals("Sergio Leone<><aa>", $.find("director").text());
-        assertEquals("Sergio Leone<><aa>", $.find("director").content());
+        assertEquals("Sergio Leone&lt;&gt;&lt;aa&gt;", $.find("director").content());
 
         // Append a new book
         // -----------------
@@ -1505,7 +1505,7 @@ public class JOOXTest {
         assertEquals(1, $.find("director").prepend("<><aa>").size());
         assertEquals(0, $.find("director").children().size());
         assertEquals("<><aa>Sergio Leone", $.find("director").text());
-        assertEquals("<><aa>Sergio Leone", $.find("director").content());
+        assertEquals("&lt;&gt;&lt;aa&gt;Sergio Leone", $.find("director").content());
 
         // Prepend a new book
         // ------------------
@@ -1535,7 +1535,7 @@ public class JOOXTest {
 
         assertEquals(0, $.find("best-director-in-the-world").replaceWith("<><aa>").size());
         assertEquals("<><aa>", $.find("directors").text().trim());
-        assertEquals("<><aa>", $.find("directors").content().trim());
+        assertEquals("&lt;&gt;&lt;aa&gt;", $.find("directors").content().trim());
 
         // Replace a new book
         // ------------------


### PR DESCRIPTION
An XML tag never contains characters &, <, >, ' and ", instead these are escaped and XML contains entity replacements like &amp;, &lt;, &gt;, &apos; and &quot;. 

Right now, content() method behaves as expected when an XML node has children but if an XML node does not have any children, content() returns text content along with these characters, which I think is a bug. As the content() method is expected to return XML content, it should always return a string which has these entity replacements instead of actual characters. If user wants the string with actual characters, they can call text() instead of content().