### PR TITLE
fix example

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Match x4 = $(document).find("book").filter(odd());
 List<String> ids = $(document).find("book").ids();
 
 // This will get all books with ID = 1 or ID = 2
-Match x5 = $(document).find("book").filter(ids(1, 2));
+Match x5 = $(document).find("book").filter(ids("1", "2"));
 
 // Or, use css-selector syntax:
 Match x6 = $(document).find("book#1, book#2");


### PR DESCRIPTION
you get "varargs mismatch; int cannot be converted to java.lang.String" 

```
jbang -s joox.jsh -i
WARNING: Using incubator modules: jdk.incubator.vector, jdk.incubator.foreign
|  Welcome to JShell -- Version 17
|  For an introduction type: /help intro

jshell> $(sample()).find("book").filter(ids(1,2))
|  Error:
|  method ids in class org.joox.JOOX cannot be applied to given types;
|    required: java.lang.String[]
|    found:    int,int
|    reason: varargs mismatch; int cannot be converted to java.lang.String
|  $(sample()).find("book").filter(ids(1,2))
|                                  ^-^
```
```